### PR TITLE
Update "The Body Beneath the Feeling" essay

### DIFF
--- a/public/blog/the-body-beneath-the-feeling/index.html
+++ b/public/blog/the-body-beneath-the-feeling/index.html
@@ -282,6 +282,7 @@
           <span><i style="background:#bf7a1e"></i>Panksepp</span>
           <span><i style="background:#6a4a9c"></i>Solms</span>
           <span><i style="background:#3f7a4d"></i>Seth</span>
+          <span><i style="background:#a8632e"></i>de Botton</span>
         </div>
         <svg viewBox="0 0 720 540" role="img" aria-label="Two-axis map of the five thinkers">
           <!-- quadrant bg -->
@@ -325,12 +326,21 @@
           <text class="svg-name" x="205" y="381" text-anchor="middle" fill="#1f6f78">Barrett</text>
           <text class="svg-small" x="205" y="417" text-anchor="middle">constructed emotion</text>
 
+          <!-- de Botton: constructed + meaning -> lower right, diagonally opposite Freud -->
+          <circle cx="540" cy="395" r="9" fill="#a8632e"/>
+          <text class="svg-name" x="540" y="381" text-anchor="middle" fill="#a8632e">de Botton</text>
+          <text class="svg-small" x="540" y="417" text-anchor="middle">emotional education · culture &amp; belief</text>
+
           <!-- coalition link Solms-Panksepp -->
           <path d="M236,143 Q360,150 461,194" fill="none" stroke="#6a4a9c" stroke-width="1.2" stroke-dasharray="4 4" opacity=".55"/>
           <text class="svg-small" x="350" y="135" text-anchor="middle" fill="#6a4a9c" opacity=".8" font-style="italic">innate-affect alliance</text>
+
+          <!-- meaning link Freud-de Botton (the personal-content right column) -->
+          <path d="M540,154 L540,366" fill="none" stroke="#a8632e" stroke-width="1.2" stroke-dasharray="4 4" opacity=".5"/>
+          <text class="svg-small" x="556" y="262" text-anchor="middle" fill="#a8632e" opacity=".85" font-style="italic" transform="rotate(90 556 262)">meaning, two routes</text>
         </svg>
       </div>
-      <figcaption><b>Fig. 2</b> &nbsp;The upper-left and upper-right share a belief in innate affect (Panksepp, Solms, the Freudian substrate); the lower-left is the constructionist corner (Barrett, with Seth as the formal go-between). The same predictive-brain mathematics is claimed by both sides.</figcaption>
+      <figcaption><b>Fig. 2</b> &nbsp;The upper half shares a belief in innate affect (Panksepp, Solms, the Freudian substrate); the lower-left is the mechanistic constructionist corner (Barrett, with Seth as the formal go-between). De Botton anchors the fourth, long-empty corner — emotion as constructed, like Barrett, yet saturated with personal meaning, like Freud. He sits diagonally opposite Freud: both treat feeling as deeply personal, and split on whether it wells up from innate drives or is assembled from culture.</figcaption>
     </figure>
   </section>
 
@@ -452,7 +462,7 @@
   <section id="room">
     <span class="sec-num">05 — The room</span>
     <h2>Who's at the table — and why</h2>
-    <p>A debate is only fair if no position wins by absence of an opponent. These five are chosen so the strongest case on each side is actually <em>present</em>. The structure is a coalition: <strong>Solms &amp; Panksepp</strong> defend innate affect and a partly-vindicated Freud; <strong>Barrett</strong> holds the constructionist line alone but ably; <strong>Seth</strong> owns the shared mathematics; <strong>Freud</strong> is the ghost they all measure against.</p>
+    <p>A debate is only fair if no position wins by absence of an opponent. These six are chosen so the strongest case on each side is actually <em>present</em>. The structure is a set of alliances: <strong>Solms &amp; Panksepp</strong> defend innate affect and a partly-vindicated Freud; <strong>Barrett</strong> holds the constructionist line, with <strong>Seth</strong> owning the shared mathematics; <strong>Freud</strong> is the ghost they all measure against; and <strong>de Botton</strong> opens the fourth front — agreeing with Barrett that emotion is constructed, but insisting it is built from meaning, not mechanism, which is the one corner the others leave empty.</p>
 
     <div class="cast">
       <div class="person freud">
@@ -498,9 +508,9 @@
       <div class="person debotton">
         <div class="ini">d</div>
         <div>
-          <h4>Alain de Botton <span style="font-weight:400;font-size:.8rem;color:var(--ink-faint)">(cameo)</span></h4>
+          <h4>Alain de Botton</h4>
           <p class="role">Applied philosophy · b. 1969</p>
-          <p>Benched from the evidence panel by design — his register is what to <em>do</em> with feeling, not where it comes from. Appears once, at the close.</p>
+          <p>The meaning-constructionist. Agrees feeling is learned, not innate — but built from culture, expectation, and self-narrative, and answerable to wisdom, not just mechanism.</p>
         </div>
       </div>
     </div>
@@ -510,21 +520,21 @@
   <section id="dialogue">
     <span class="sec-num">06 — The debate</span>
     <h2>A staged debate</h2>
-    <div class="scene">SCENE — A dim trail at dusk. A coiled shape lies across the path. The walker's heart slams, breath catches, the body recoils — and half a second later: it is a stick. On the table, one shared premise: <b>the brain is a prediction machine that regulates the body.</b> Everyone agrees on that sentence. On what just happened, they agree on almost nothing.</div>
+    <div class="scene">SCENE — A dim trail at dusk. A coiled shape lies across the path. The walker's heart slams, breath catches, the body recoils — and half a second later: it is a coiled length of rope. On the table, one shared premise: <b>the brain is a prediction machine that regulates the body.</b> Everyone agrees on that sentence. On what just happened, they agree on almost nothing.</div>
 
     <div class="turn freud">
       <span class="who">Freud</span>
-      <p>The stick does not interest me. The snake does. Of all the things a dim curve on the ground might have been, your mind reached for the one charged with dread. Why that image, and so fast? The snake was in you before it was on the path. Perception handed back what you were primed — and perhaps, in older and more personal ways, disposed — to fear.</p>
+      <p>The rope does not interest me. The snake does. Of all the things a dim coil on the ground might have been, your mind reached for the one charged with dread. Why that image, and so fast? The snake was in you before it was on the path. Perception handed back what you were primed — and perhaps, in older and more personal ways, disposed — to fear.</p>
     </div>
 
     <div class="turn barrett">
       <span class="who">Barrett</span>
-      <p>Just so — except what was "in you" is a concept, not a buried symbol. Poor light, sparse data; your brain ran its best guess, and "snake" carried the highest stakes, so it won. The percept and the fear were built together, before any snake was confirmed. Better light arrived, the prediction updated to "stick." Nothing was uncovered. A guess was corrected.</p>
+      <p>Just so — except what was "in you" is a concept, not a buried symbol. Poor light, sparse data; your brain ran its best guess, and "snake" carried the highest stakes, so it won. The percept and the fear were built together, before any snake was confirmed. Better light arrived, the prediction updated to "rope." Nothing was uncovered. A guess was corrected.</p>
     </div>
 
     <div class="turn panksepp">
       <span class="who">Panksepp</span>
-      <p>And notice the order of events. The body was already moving — heart, legs, a jump back — before "snake," let alone "stick," reached awareness. That is an evolved alarm system firing on the prediction, a circuit that would rather flinch at a hundred sticks than miss one snake. The affect led; the concept caught up. The feeling did not wait on the word.</p>
+      <p>And notice the order of events. The body was already moving — heart, legs, a jump back — before "snake," let alone "rope," reached awareness. That is an evolved alarm system firing on the prediction, a circuit that would rather flinch at a hundred ropes than miss one snake. The affect led; the concept caught up. The feeling did not wait on the word.</p>
     </div>
 
     <div class="turn barrett">
@@ -534,7 +544,7 @@
 
     <div class="turn seth">
       <span class="who">Seth</span>
-      <p>This is the cleanest case there is, so let me say the strong version. You did not see the path; you saw your brain's best guess of it, caught for an instant out of step with the world. Perception is a controlled hallucination — built top-down from prediction, reined in by sensory error. And the proportions are humbling: into the brain's visual relay, only about a tenth of the signal comes from the eyes. The rest is the brain's own model. The "stick" correction is that thin incoming stream doing its work in real time.</p>
+      <p>This is the cleanest case there is, so let me say the strong version. You did not see the path; you saw your brain's best guess of it, caught for an instant out of step with the world. Perception is a controlled hallucination — built top-down from prediction, reined in by sensory error. And the proportions are humbling: into the brain's visual relay, only about a tenth of the signal comes from the eyes. The rest is the brain's own model. The "rope" correction is that thin incoming stream doing its work in real time.</p>
     </div>
 
     <div class="turn solms">
@@ -547,6 +557,16 @@
       <p>On the loop, agreed — and Mark, we run on the <em>same</em> equation. We part on what the guess <em>contains</em>. You hear drive, conflict, personal meaning. I hear stakes-weighted statistics with no story to tell until a concept supplies one.</p>
     </div>
 
+    <div class="turn debotton">
+      <span class="who">de Botton</span>
+      <p>"No story to tell" — there, Lisa, is where I leave you, though we agree the feeling is made and not buried. The rope is the trivial case. The fears that actually run a life — that I am unlovable, that I have wasted my best years, that I am falling behind people I did not choose to race — are constructed too, exactly as you insist. But they are made of almost nothing but story: ideas absorbed from a culture, expectations no one set out deliberately to hold, comparisons we were schooled into. Strip the narrative from those and there is no residue of "stakes-weighted statistics" underneath. The meaning is not a label fixed onto a body-state. For the feelings that matter most, the meaning <em>is</em> the emotion.</p>
+    </div>
+
+    <div class="turn barrett">
+      <span class="who">Barrett</span>
+      <p>I'd still say the story rides on an affective current — the body sinks before "failure" names the sinking. But I grant you the interesting half: the richer and more cultural the concept, the more the construction floats free of the flesh. On the rope, biology does most of the work. On a wasted decade, your culture does.</p>
+    </div>
+
     <div class="turn freud">
       <span class="who">Freud</span>
       <p>That the guess reached for a snake and not a rope is the meaning. The content of our errors is a kind of confession.</p>
@@ -554,7 +574,7 @@
 
     <div class="turn seth">
       <span class="who">Seth</span>
-      <p>Or simply a prior. Snakes have killed more of our ancestors than sticks have; the bias is paid for in evolutionary time and needs no biography. This is the crux, and worth saying plainly: the maths is neutral. It can tell us the brain predicts and corrects — it is far quieter on whether the prediction is a <em>meaning</em> or a <em>mechanism</em>. Some of this disagreement is interpretation wearing the costume of evidence.</p>
+      <p>Or simply a prior. Snakes have killed more of our ancestors than ropes have; the bias is paid for in evolutionary time and needs no biography. This is the crux, and worth saying plainly: the maths is neutral. It can tell us the brain predicts and corrects — it is far quieter on whether the prediction is a <em>meaning</em> or a <em>mechanism</em>. Some of this disagreement is interpretation wearing the costume of evidence.</p>
     </div>
 
     <div class="turn panksepp">
@@ -567,19 +587,24 @@
       <p>And the leverage is in the part that is learned. Widen the light, sharpen the concepts, and the same shape stops being a snake on sight. We are not only the prediction — we can school it. That is testable, and it is hopeful.</p>
     </div>
 
+    <div class="turn debotton">
+      <span class="who">de Botton</span>
+      <p>There, at last, we shake hands — the feeling is teachable. You would retrain it with finer concepts and graded exposure; I would do it with Seneca, with a novel, with a truer picture of what a life actually owes a person. Same wager, Lisa. We differ only on the curriculum — and mine has a four-thousand-year head start.</p>
+    </div>
+
     <div class="turn seth">
       <span class="who">Seth</span>
-      <p>Which returns us to the path. Notice no one here thinks the snake was simply <em>there</em>, waiting to be seen. We split on what produced it — a primed symbol, an evolved alarm, a stakes-weighted prior, a concept reaching past its data — and on whether the correction reveals a hidden basement or just a better-lit trail. Four readings, one stick.</p>
+      <p>Which returns us to the path. Notice no one here thinks the snake was simply <em>there</em>, waiting to be seen. We split on what produced it — a primed symbol, an evolved alarm, a stakes-weighted prior, a concept reaching past its data, a story we were handed and never examined — and on whether the correction reveals a hidden basement or just a better-lit trail. Five readings, one rope.</p>
     </div>
 
     <div class="turn debotton">
-      <span class="who">de Botton — from the doorway</span>
-      <p>May I, as the amateur? The trail is a parable. Most of what we dread is the stick that looked like a snake — the unanswered message, the colleague's glance, read in poor light by a frightened animal. Whatever the machinery beneath it, Seneca already drew the lesson worth keeping: we suffer more often in imagination than in reality. You may not need the fMRI to use that.</p>
+      <span class="who">de Botton</span>
+      <p>And a consoling reading to end on. Most of what we dread is the rope that looked like a snake — the unanswered message, the colleague's glance, the silence after an interview — each read in poor light by a frightened animal. Whatever the machinery beneath it, Seneca drew the lesson worth keeping two thousand years ago: we suffer more often in imagination than in reality. You do not need the fMRI to start using that tonight.</p>
     </div>
 
     <div class="synth">
       <h3>Where it actually lands</h3>
-      <p>No one wins, and that is the honest result. There is real consensus that the brain predicts and corrects — that we meet the world through a best guess, with the senses feeding back only enough to keep the guess honest. The disagreement has migrated <em>upward</em>: from "is perception a construction?" (settled: largely yes) to "do its guesses carry personal meaning, or only mechanism?" — which is Freud versus Barrett, now asked on a darkening trail. Seth's caution is the one to leave with: the same equation underwrites both readings, so be suspicious when interpretation is dressed as proof.</p>
+      <p>No one wins, and that is the honest result. There is real consensus that the brain predicts and corrects — that we meet the world through a best guess, with the senses feeding back only enough to keep the guess honest. The disagreement has migrated <em>upward</em>: from "is perception a construction?" (settled: largely yes) to "what is the construction made of?" Mechanism, says Barrett; buried meaning, says Freud; inherited story, says de Botton — three answers that no longer divide neatly into innate versus learned. Seth's caution is the one to leave with: the same equation underwrites all of them, so be suspicious when interpretation is dressed as proof.</p>
     </div>
   </section>
 

--- a/public/blog/the-body-beneath-the-feeling/index.html
+++ b/public/blog/the-body-beneath-the-feeling/index.html
@@ -271,7 +271,7 @@
   <!-- POSITIONS -->
   <section id="positions">
     <span class="sec-num">02 — The map</span>
-    <h2>Five positions on two axes</h2>
+    <h2>Six positions on two axes</h2>
     <p>The arguments resolve onto two questions. <strong>Where do emotions come from</strong> — are they evolved and innate, or built from learning and culture? And <strong>what sits beneath awareness</strong> — a store of personal <em class="term">meaning</em>, or impersonal regulatory <em class="term">process</em>? Plot every thinker against those two axes and the alliances become visible.</p>
 
     <figure>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Updates the standalone essay page at `public/blog/the-body-beneath-the-feeling/index.html` to match the revised manuscript.

## What changed

- **Alain de Botton promoted from cameo to full participant.** He now anchors a fourth corner of the conceptual map (emotion as *constructed*, like Barrett, yet saturated with *personal meaning*, like Freud — diagonally opposite Freud).
  - Fig. 2 map: added de Botton's point in the lower-right (meaning + constructed) quadrant, a "meaning, two routes" link to Freud, an updated legend, and a rewritten caption.
  - Section 05 ("The room"): intro now describes six participants and a set of alliances; de Botton's cast card rewritten from "(cameo)" to "the meaning-constructionist."
  - Section 06 debate: added two substantive de Botton turns (the "for the feelings that matter most, the meaning *is* the emotion" argument and the "same wager, different curriculum" exchange), plus his new consoling close.
- **Thought-experiment object changed from a "stick" to a "rope"** throughout the scene and dialogue.
- **Seth's closing line** now reads "Five readings, one rope" and includes "a story we were handed and never examined."
- **"Where it actually lands" synthesis** rewritten to name three answers (mechanism / buried meaning / inherited story).

## Verification

`npm run build` completes successfully (the empty `blog` content-collection warning is pre-existing and expected per `AGENTS.md`). Only the `public/` source is committed; `docs/` build artifacts are regenerated by CI on deploy.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-27fd109b-6887-49e2-8a90-d29531954377"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-27fd109b-6887-49e2-8a90-d29531954377"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

