### PR TITLE
Improve mobile UX for longevity article interactive panels

### DIFF
--- a/public/blog/longevity-diet-research/index.html
+++ b/public/blog/longevity-diet-research/index.html
@@ -349,7 +349,11 @@
     var heading = node.querySelector("h3, h4");
     if (heading) return heading.textContent.trim();
     var titleDiv = node.querySelector("div");
-    if (titleDiv) return titleDiv.textContent.trim();
+    if (titleDiv) {
+      var firstSpan = titleDiv.querySelector("span");
+      if (firstSpan) return firstSpan.textContent.trim();
+      return titleDiv.textContent.trim();
+    }
     return "";
   }
 
@@ -396,6 +400,18 @@
       closeMobileModal();
     }
   });
+
+  if (window.matchMedia) {
+    var mql = window.matchMedia("(max-width: 720px)");
+    var onBreakpointChange = function(e) {
+      if (!e.matches) closeMobileModal();
+    };
+    if (mql.addEventListener) {
+      mql.addEventListener("change", onBreakpointChange);
+    } else {
+      mql.addListener(onBreakpointChange);
+    }
+  }
 })();
 </script>
 </head>

--- a/public/blog/longevity-diet-research/index.html
+++ b/public/blog/longevity-diet-research/index.html
@@ -210,6 +210,69 @@
     box-shadow: var(--shadow-glow);
   }
   [data-panel][data-open="false"] { display: none; }
+  body.lv-modal-open { overflow: hidden; }
+
+  .lv-mobile-modal {
+    position: fixed;
+    inset: 0;
+    z-index: 100;
+    display: none;
+    align-items: flex-end;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.42);
+    padding: 0;
+  }
+  .lv-mobile-modal.is-open { display: flex; }
+  .lv-mobile-modal__sheet {
+    width: 100%;
+    max-height: 85vh;
+    overflow: hidden;
+    background: var(--color-bg-surface);
+    border-top-left-radius: 18px;
+    border-top-right-radius: 18px;
+    border: 1px solid var(--color-border);
+    border-bottom: 0;
+    box-shadow: 0 -8px 28px rgba(0, 0, 0, 0.2);
+    transform: translateY(8px);
+    transition: transform var(--transition-base);
+  }
+  .lv-mobile-modal.is-open .lv-mobile-modal__sheet {
+    transform: translateY(0);
+  }
+  .lv-mobile-modal__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 14px 16px;
+    border-bottom: 1px solid var(--color-border);
+    background: var(--color-bg-elevated);
+  }
+  .lv-mobile-modal__title {
+    margin: 0;
+    font-size: 1rem;
+    line-height: 1.3;
+    color: var(--color-text-primary);
+  }
+  .lv-mobile-modal__close {
+    border: 1px solid var(--color-border);
+    background: var(--color-bg-surface);
+    color: var(--color-text-primary);
+    border-radius: 999px;
+    min-width: 34px;
+    height: 34px;
+    cursor: pointer;
+    font-size: 1.1rem;
+    line-height: 1;
+  }
+  .lv-mobile-modal__content {
+    max-height: calc(85vh - 64px);
+    overflow-y: auto;
+    padding: 14px 16px 28px;
+  }
+  .lv-mobile-modal__content h3:first-child {
+    margin-top: 0;
+  }
 
   @media (max-width: 900px) {
     .lv-wrap { padding: 24px 18px 64px; }
@@ -257,6 +320,10 @@
     if (target) {
       target.setAttribute("data-open", "true");
       t.setAttribute("data-active", "true");
+      var isMobile = window.matchMedia && window.matchMedia("(max-width: 720px)").matches;
+      if (isMobile && (group === "week" || group === "diet")) {
+        openMobileModal(t, target);
+      }
     }
   });
 
@@ -274,6 +341,59 @@
     if (t && t.getAttribute && (t.getAttribute("data-toggle") || t.getAttribute("data-goto"))) {
       ev.preventDefault();
       t.click();
+    }
+  });
+
+  function getCardTitle(node) {
+    if (!node || !node.querySelector) return "";
+    var heading = node.querySelector("h3, h4");
+    if (heading) return heading.textContent.trim();
+    var titleDiv = node.querySelector("div");
+    if (titleDiv) return titleDiv.textContent.trim();
+    return "";
+  }
+
+  function openMobileModal(card, panel) {
+    var modal = document.getElementById("lv-mobile-modal");
+    if (!modal) return;
+    var title = modal.querySelector("#lv-mobile-modal-title");
+    var content = modal.querySelector("#lv-mobile-modal-content");
+    if (!content || !title) return;
+
+    var cardTitle = getCardTitle(card);
+    var group = card.getAttribute("data-toggle");
+    title.textContent = cardTitle || (group === "week" ? "Weekly plate details" : "Diet analysis details");
+    content.innerHTML = panel.innerHTML;
+    modal.classList.add("is-open");
+    modal.setAttribute("aria-hidden", "false");
+    document.body.classList.add("lv-modal-open");
+  }
+
+  function closeMobileModal() {
+    var modal = document.getElementById("lv-mobile-modal");
+    if (!modal) return;
+    modal.classList.remove("is-open");
+    modal.setAttribute("aria-hidden", "true");
+    document.body.classList.remove("lv-modal-open");
+  }
+
+  document.addEventListener("click", function(ev) {
+    var closeBtn = closestInPath(ev, function(node) { return node && node.id === "lv-mobile-modal-close"; });
+    if (closeBtn) {
+      closeMobileModal();
+      return;
+    }
+
+    var backdrop = closestInPath(ev, function(node) { return node && node.id === "lv-mobile-modal"; });
+    var sheet = closestInPath(ev, function(node) { return node && node.classList && node.classList.contains("lv-mobile-modal__sheet"); });
+    if (backdrop && !sheet) {
+      closeMobileModal();
+    }
+  });
+
+  document.addEventListener("keydown", function(ev) {
+    if (ev.key === "Escape") {
+      closeMobileModal();
     }
   });
 })();
@@ -600,6 +720,16 @@
       </ol>
     </div>
   </article>
+
+  <div id="lv-mobile-modal" class="lv-mobile-modal" aria-hidden="true">
+    <div class="lv-mobile-modal__sheet" role="dialog" aria-modal="true" aria-labelledby="lv-mobile-modal-title">
+      <div class="lv-mobile-modal__header">
+        <h3 id="lv-mobile-modal-title" class="lv-mobile-modal__title">Details</h3>
+        <button id="lv-mobile-modal-close" class="lv-mobile-modal__close" type="button" aria-label="Close details popup">×</button>
+      </div>
+      <div id="lv-mobile-modal-content" class="lv-mobile-modal__content"></div>
+    </div>
+  </div>
 </div>
 </body>
 </html>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a mobile-friendly popup sheet for interactive content blocks in the longevity article
- when a user taps a `week` or `diet` card on small screens, the corresponding dynamic panel content now opens in a visible modal instead of changing out of view
- keep desktop behavior unchanged while preserving all existing panel toggle functionality
- include close controls, backdrop-dismiss, Escape key support, and body scroll lock while popup is open

## Validation
- `npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6f93ade1-76fe-40f3-ab8d-35e97a06be75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6f93ade1-76fe-40f3-ab8d-35e97a06be75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

